### PR TITLE
Add the rest of the functions

### DIFF
--- a/vendors/aws/README.md
+++ b/vendors/aws/README.md
@@ -10,6 +10,8 @@ Implementation of AWS Lambda serverless functions.
 * `hello` - simple hello world - testing the cold start 
 * `object_storage_upload` - S3 upload  - for the vendor's object storage solution (uploads a 50MB object and returns
     the execution time)
+* `get_resources` - return the information about the CPU and memory used on the runtime
+* `simulate_cpu_load` - returns the time in miliseconds elapsed while performing some computation of a given size (specified by the parameter).
 
 ## Structure
 `bin` folder contains various scripts required for building and deploying the lambdas:
@@ -28,6 +30,8 @@ with proper S3. On dev environment it connects to `minio` (the `localstack` didn
 
 To test out the lambdas the `1-deploy-local-lambda.sh` scripts will print out the lambda's url on completion. All you
 need is to perform an HTTP request against it.
+
+The `simulate cpu load` function requires to pass a `numberOfIterations` query parameter to the HTTP url.
 
 ## Dev environment
 Before deploying to the cloud we can freely test given lambdas by deploying them to local environment provided

--- a/vendors/aws/bin/0-prepare-lambda.sh
+++ b/vendors/aws/bin/0-prepare-lambda.sh
@@ -3,5 +3,5 @@
 npm install
 
 rm -rd lambda.zip
-zip -r lambda.zip object_storage_upload.js hello.js node_modules package.json package-lock.json
+zip -r lambda.zip object_storage_upload.js hello.js get_resources.js simulate_cpu_load.js node_modules package.json package-lock.json
 

--- a/vendors/aws/get_resources.js
+++ b/vendors/aws/get_resources.js
@@ -1,0 +1,14 @@
+module.exports.handler = async function(event) {
+  var os = require('os');
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      cpus: os.cpus(),
+      totalmem: os.totalmem(), 
+      freemem: os.freemem()
+    }),
+    headers: {"content-type": "application/json"}
+  }
+}
+

--- a/vendors/aws/simulate_cpu_load.js
+++ b/vendors/aws/simulate_cpu_load.js
@@ -1,0 +1,29 @@
+function simulateLoad(numberOfIterations) {
+  sum = 0;
+  for(var i=0; i<numberOfIterations; i++) {
+    sum+=1;
+  }
+}
+module.exports.handler = async function(event) {
+  try{
+    const startTime = new Date();
+    simulateLoad(event['queryStringParameters']['numberOfIterations']);
+    const endTime = new Date();
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        elapsedTimeMs: (endTime-startTime)
+      }),
+      headers: {"content-type": "application/json"}
+    }
+} catch (error) {
+    console.error(error);
+
+    return {
+      statusCode: 500,
+      body: JSON.stringify(error)
+    };
+  }
+}
+

--- a/vendors/azure/README.md
+++ b/vendors/azure/README.md
@@ -4,7 +4,7 @@ Implementation of Azure Function serverless functions.
 ## Requirements
 * `docker`
 * `docker-compose`
-* `acure-functions-core-tools@4`
+* `azure-functions-core-tools@4`
 
 ## Implemented functions
 * `hello` - simple hello world - testing the cold start 
@@ -12,15 +12,26 @@ Implementation of Azure Function serverless functions.
     the execution time)
 
 ## Structure
-Each of the functions has its own folder. To run any of them locally use any of following commands:
+Each of the functions has its own folder.
+First, install the dependencies:
+```
+npm ci
+``` 
+To run any of them locally use any of following commands:
 ```bash
 # run the hello function
 func start hello
 # run the storage function
 func start object_storage_upload
+# run the get resources function
+func start get_resources
+# run the simulate cpu load function
+func start get_resources
 ```
 
 To run the storage function locally you need to run `azurite` with given `docker-compose` setup.
+
+The `simulate cpu load` function requires to pass a `numberOfIterations` query parameter to the HTTP url.
 
 In case of local development and storage function couple of environmental variables are required (but
 provided inside `.env` file):

--- a/vendors/azure/get_resources/function.json
+++ b/vendors/azure/get_resources/function.json
@@ -6,7 +6,7 @@
       "direction": "in",
       "name": "req",
       "methods": [
-        "get",
+        "get"
       ]
     },
     {

--- a/vendors/azure/get_resources/index.js
+++ b/vendors/azure/get_resources/index.js
@@ -1,0 +1,15 @@
+
+module.exports = async function (context, req){
+  var os = require('os');
+
+  context.res = {
+    status: 200,
+    body: JSON.stringify({
+      cpus: os.cpus(),
+      totalmem: os.totalmem(), 
+      freemem: os.freemem()
+    }),
+    headers: {"content-type": "application/json"}
+  }
+}
+

--- a/vendors/azure/simulate_cpu_load/function.json
+++ b/vendors/azure/simulate_cpu_load/function.json
@@ -1,0 +1,18 @@
+{
+  "bindings": [
+    {
+      "authLevel": "Anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/vendors/azure/simulate_cpu_load/index.js
+++ b/vendors/azure/simulate_cpu_load/index.js
@@ -1,0 +1,30 @@
+function simulateLoad(numberOfIterations) {
+  sum = 0;
+  for(var i=0; i<numberOfIterations; i++) {
+    sum+=1;
+  }
+}
+
+module.exports = async function (context, req){
+  try{
+    const startTime = new Date();
+    console.error(req);
+    simulateLoad(req['query']['numberOfIterations']);
+    const endTime = new Date();
+
+    context.res = {
+      status: 200,
+      body: JSON.stringify({
+        elapsedTimeMs: (endTime-startTime)
+      }),
+      headers: {"content-type": "application/json"}
+    }
+} catch (error) {
+    console.error(error);
+    context.res = {
+      status: 500,
+      body: JSON.stringify(error)
+    };
+  }
+}
+

--- a/vendors/azure/simulate_cpu_load/index.js
+++ b/vendors/azure/simulate_cpu_load/index.js
@@ -8,7 +8,6 @@ function simulateLoad(numberOfIterations) {
 module.exports = async function (context, req){
   try{
     const startTime = new Date();
-    console.error(req);
     simulateLoad(req['query']['numberOfIterations']);
     const endTime = new Date();
 

--- a/vendors/gcp/README.md
+++ b/vendors/gcp/README.md
@@ -9,12 +9,17 @@ Implementation of GCP Cloud Function serverless functions.
 * `hello` - simple hello world - testing the cold start 
 * `object_storage_upload` - Google Cloud Storage upload  - for the vendor's object storage solution (uploads a 50MB object and returns
     the execution time)
+* `get_resources` - return the information about the CPU and memory used on the runtime
+* `simulate_cpu_load` - returns the time in miliseconds elapsed while performing some computation of a given size (specified by the parameter). 
 
 
 ## Structure
 All functions are implemented in a single file `index.js`.
-
-To run them locally one can run the following commands:
+First, install the required dependencies:
+```
+npm ci
+```
+To run the functions locally one can run the following commands:
 ```bash
 # run the hello function
 npm run hello
@@ -32,6 +37,8 @@ for the first time:
 // await storage.createBucket(process.env.STORAGE_BUCKET);
 ```
 
-Also to test the storage function one needs to run the `docker-compose` which consists of a fakte Google Cloud Storage 
+Also to test the storage function one needs to run the `docker-compose` which consists of a fake Google Cloud Storage 
 container.
+
+The `simulate cpu load` function requires to pass a `numberOfIterations` query parameter to the HTTP url.
 

--- a/vendors/gcp/bin/0-deploy-function.sh
+++ b/vendors/gcp/bin/0-deploy-function.sh
@@ -2,7 +2,7 @@
 FUNCTION_NAME=$1
 
 # NOTE: this will require logging to gcp and making sure that the function has access to google storage
-gcloud functions 
+gcloud functions \
   deploy $FUNCTION_NAME \
   --runtime nodejs16 \
   --trigger-http \

--- a/vendors/gcp/index.js
+++ b/vendors/gcp/index.js
@@ -6,9 +6,35 @@ functions.http("hello", (_req, res) => {
   res.send("Hello world!");
 });
 
+functions.http("get_resources", (_req, res) => {
+  var os = require('os');
+  res.send(JSON.stringify({
+    cpus: os.cpus(),
+    totalmem: os.totalmem(), 
+    freemem: os.freemem()
+  }));
+});
+
+function simulateLoad(numberOfIterations) {
+  sum = 0;
+  for(var i=0; i<numberOfIterations; i++) {
+    sum+=1;
+  }
+  return sum;
+}
+
+functions.http("simulate_cpu_load", (req, res) => {
+  const startTime = new Date();
+  var result = simulateLoad(req['query']['numberOfIterations']);
+  const endTime = new Date();
+  res.send(JSON.stringify({
+      elapsedTimeMs: (endTime-startTime)  
+    }));
+});
+
+
 function createPayload(size) {
   return Buffer.from(new Uint8Array(size));
-
 }
 
 functions.http('object_storage_upload', async (_req, res) => {

--- a/vendors/gcp/logs.log
+++ b/vendors/gcp/logs.log
@@ -1,4 +1,0 @@
-
-> gcp@1.0.0 simulate_cpu_load
-> npx functions-framework --target=simulate_cpu_load
-

--- a/vendors/gcp/logs.log
+++ b/vendors/gcp/logs.log
@@ -1,0 +1,4 @@
+
+> gcp@1.0.0 simulate_cpu_load
+> npx functions-framework --target=simulate_cpu_load
+

--- a/vendors/gcp/package.json
+++ b/vendors/gcp/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "hello": "npx functions-framework --target=hello",
-    "storage": "npx functions-framework --target=object_storage_upload"
+    "storage": "npx functions-framework --target=object_storage_upload",
+    "get_resources": "npx functions-framework --target=get_resources",
+    "simulate_cpu_load": "npx functions-framework --target=simulate_cpu_load"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
This PR:
* Adds `get_resources` and `simulate_cpu_workload` functions for each of the vendors. 
* Improves the readme in GPC and Azure by adding information that `npm ci` is required to be run